### PR TITLE
feat: リソース画面のメールサポート機能追加

### DIFF
--- a/app/resources.tsx
+++ b/app/resources.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { StyleSheet, Text, View, ScrollView, TouchableOpacity, TextInput } from 'react-native';
+import { StyleSheet, Text, View, ScrollView, TouchableOpacity, TextInput, Linking, Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import AuthGuard from '../components/AuthGuard';
 import resourceService from '../services/resourceService';
@@ -490,17 +490,72 @@ export default function Resources() {
         <View style={styles.contactSection}>
           <Text style={styles.contactSectionTitle}>お問い合わせ</Text>
           
-          <TouchableOpacity style={styles.contactButton}>
+          <TouchableOpacity 
+            style={styles.contactButton}
+            onPress={() => {
+              const email = 'tizuka0@gmail.com';
+              const subject = 'PeerLearningHub - サポートのお問い合わせ';
+              const body = 'お疲れ様です。\n\nPeerLearningHubについてお問い合わせがあります。\n\n【お問い合わせ内容】\n\n\n【ご利用環境】\n- デバイス: \n- OS: \n- アプリバージョン: \n\nよろしくお願いいたします。';
+              const mailtoUrl = `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+              
+              Linking.canOpenURL(mailtoUrl)
+                .then((supported) => {
+                  if (supported) {
+                    return Linking.openURL(mailtoUrl);
+                  } else {
+                    Alert.alert(
+                      'メールアプリが見つかりません',
+                      `メールアプリがインストールされていないか、設定されていません。\n\n直接以下のメールアドレスにお問い合わせください：\n${email}`,
+                      [
+                        { text: 'キャンセル', style: 'cancel' },
+                        { 
+                          text: 'メールアドレスをコピー', 
+                          onPress: () => {
+                            // クリップボードにコピー機能は別途実装可能
+                            Alert.alert('メールアドレス', email);
+                          }
+                        }
+                      ]
+                    );
+                  }
+                })
+                .catch((err) => {
+                  console.error('メール送信エラー:', err);
+                  Alert.alert(
+                    'エラー',
+                    `メールアプリを開けませんでした。\n\n直接以下のメールアドレスにお問い合わせください：\n${email}`
+                  );
+                });
+            }}
+          >
             <Text style={styles.contactIcon}>📧</Text>
             <Text style={styles.contactText}>メールサポート</Text>
           </TouchableOpacity>
           
-          <TouchableOpacity style={styles.contactButton}>
+          <TouchableOpacity 
+            style={styles.contactButton}
+            onPress={() => {
+              Alert.alert(
+                'チャットサポート',
+                'チャットサポートは現在準備中です。\n\nお急ぎの場合は、メールサポートをご利用ください。',
+                [{ text: 'OK' }]
+              );
+            }}
+          >
             <Text style={styles.contactIcon}>💬</Text>
             <Text style={styles.contactText}>チャットサポート</Text>
           </TouchableOpacity>
           
-          <TouchableOpacity style={styles.contactButton}>
+          <TouchableOpacity 
+            style={styles.contactButton}
+            onPress={() => {
+              Alert.alert(
+                '電話サポート',
+                '電話サポートは現在準備中です。\n\nお問い合わせは、メールサポートをご利用ください。',
+                [{ text: 'OK' }]
+              );
+            }}
+          >
             <Text style={styles.contactIcon}>📞</Text>
             <Text style={styles.contactText}>電話サポート</Text>
           </TouchableOpacity>


### PR DESCRIPTION
✨ 新機能:
- メールサポートボタンにtizuka0@gmail.com宛のメール送信機能追加
- 件名と本文テンプレートを自動設定
- メールアプリが利用できない場合のフォールバック処理

📧 メール機能詳細:
- 宛先: tizuka0@gmail.com
- 件名: PeerLearningHub - サポートのお問い合わせ
- 本文テンプレート: お問い合わせ内容とご利用環境の記入欄付き
- エラーハンドリング: メールアプリ未対応時の案内表示

🔧 その他の改善:
- チャットサポート・電話サポートボタンに準備中メッセージ追加
- 適切なユーザーフィードバック実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email contact now opens your default mail app with a prefilled subject and body. If not supported, you’ll get an option to copy the email address, with clear error alerts on failures.
  * Chat and Phone contact buttons now show informative alerts indicating these options are coming soon.
  * Overall contact actions are more responsive with real-world interactions and improved error handling, while the UI remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->